### PR TITLE
Ruby indentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Edit the `homepage/handler.rb` file to return some HTML:
 
 ```ruby
 class Handler
-    def run(body, headers)
-        response_headers = {"content-type": "text/html"}
-        body = "<html>Hello world from the Ruby template</html>"
+  def run(body, headers)
+    response_headers = {"content-type": "text/html"}
+    body = "<html>Hello world from the Ruby template</html>"
 
-        return body, response_headers
-    end
+    return body, response_headers
+  end
 end
 ```
 

--- a/template/ruby-http/function/handler.rb
+++ b/template/ruby-http/function/handler.rb
@@ -1,8 +1,8 @@
 class Handler
-    def run(body, headers)
-        response_headers = {"content-type": "text/plain"}
-        body = "Hello world from the Ruby template"
+  def run(body, headers)
+    response_headers = {"content-type": "text/plain"}
+    body = "Hello world from the Ruby template"
 
-        return body, response_headers
-    end
+    return body, response_headers
+  end
 end

--- a/template/ruby-http/index.rb
+++ b/template/ruby-http/index.rb
@@ -37,4 +37,3 @@ delete '/*' do
 
     return res
 end
-  

--- a/template/ruby-http/template.yml
+++ b/template/ruby-http/template.yml
@@ -1,8 +1,8 @@
 language: ruby
 fprocess: ruby index.rb
-build_options: 
+build_options:
   - name: dev
-    packages: 
+    packages:
       - make
       - automake
       - gcc


### PR DESCRIPTION
As in https://github.com/openfaas/templates/pull/83 formats code according to usual ruby styling ¯\\_(ツ)_/¯

## Description
In Ruby, code is usually indented with 2 spaces instead of 4

https://github.com/rubocop-hq/ruby-style-guide#source-code-layout

Also includes some additional trailing whitespace removal

### Why is this necessary?
It's not, but let's keep it consistent^^