### PR TITLE
Fix: Actually set headers in sinatra routes

### DIFF
--- a/template/ruby-http/index.rb
+++ b/template/ruby-http/index.rb
@@ -13,27 +13,23 @@ handler = Handler.new
 get '/*' do
   res, res_headers = handler.run request.body, request.env
 
-  headers = res_headers
-
-  return res
+  [200, res_headers, res]
 end
 
 post '/*' do
-    res, res_headers = handler.run request.body, request.env
-    headers = res_headers
-    return res
+  res, res_headers = handler.run request.body, request.env
+
+  [200, res_headers, res]
 end
 
 put '/*' do
-    res, res_headers = handler.run request.body, request.env
-    headers = res_headers
+  res, res_headers = handler.run request.body, request.env
 
-    return res
+  [200, res_headers, res]
 end
 
 delete '/*' do
-    res, res_headers = handler.run request.body, request.env
-    headers = res_headers
+  res, res_headers = handler.run request.body, request.env
 
-    return res
+  [200, res_headers, res]
 end


### PR DESCRIPTION
The headers weren't actually set previously. The statement `headers = res_headers` doesn't have any effect, since it only creates a local variable. The correct statement would look like `headers res_headers` (i.e. call the method `headers`).

I changed the code to use the return triplet ` [status, headers, response body]` though which is the recommended way (see http://sinatrarb.com/intro.html).