### PR TITLE
Add the repo to the template pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Usage:
 
 ```
-faas template pull
+faas template pull https://github.com/openfaas-incubator/ruby-http
 faas new --lang ruby-http homepage
 ```
 


### PR DESCRIPTION
The README for the `faas template pull` command is currently missing the repository url.