### PR TITLE
Add optional response status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Edit the `homepage/handler.rb` file to return some HTML:
 ```ruby
 class Handler
   def run(body, headers)
+    status_code = 200 # Optional status code, defaults to 200
     response_headers = {"content-type": "text/html"}
     body = "<html>Hello world from the Ruby template</html>"
 
-    return body, response_headers
+    return body, response_headers, status_code
   end
 end
 ```

--- a/template/ruby-http/function/handler.rb
+++ b/template/ruby-http/function/handler.rb
@@ -1,8 +1,9 @@
 class Handler
   def run(body, headers)
+    status_code = 200 # Optional status code, defaults to 200
     response_headers = {"content-type": "text/plain"}
     body = "Hello world from the Ruby template"
 
-    return body, response_headers
+    return body, response_headers, status_code
   end
 end

--- a/template/ruby-http/index.rb
+++ b/template/ruby-http/index.rb
@@ -11,25 +11,25 @@ set :port, 5000
 handler = Handler.new
 
 get '/*' do
-  res, res_headers = handler.run request.body, request.env
+  res, res_headers, status = handler.run request.body, request.env
 
-  [200, res_headers, res]
+  [status || 200, res_headers, res]
 end
 
 post '/*' do
-  res, res_headers = handler.run request.body, request.env
+  res, res_headers, status = handler.run request.body, request.env
 
-  [200, res_headers, res]
+  [status || 200, res_headers, res]
 end
 
 put '/*' do
-  res, res_headers = handler.run request.body, request.env
+  res, res_headers, status = handler.run request.body, request.env
 
-  [200, res_headers, res]
+  [status || 200, res_headers, res]
 end
 
 delete '/*' do
-  res, res_headers = handler.run request.body, request.env
+  res, res_headers, status = handler.run request.body, request.env
 
-  [200, res_headers, res]
+  [status || 200, res_headers, res]
 end

--- a/template/ruby-http/index.rb
+++ b/template/ruby-http/index.rb
@@ -13,27 +13,23 @@ handler = Handler.new
 get '/*' do
   res, res_headers = handler.run request.body, request.env
 
-  headers = res_headers
-
-  return res
+  [200, res_headers, res]
 end
 
 post '/*' do
-    res, res_headers = handler.run request.body, request.env
-    headers = res_headers
-    return res
+  res, res_headers = handler.run request.body, request.env
+
+  [200, res_headers, res]
 end
 
 put '/*' do
-    res, res_headers = handler.run request.body, request.env
-    headers = res_headers
+  res, res_headers = handler.run request.body, request.env
 
-    return res
+  [200, res_headers, res]
 end
 
 delete '/*' do
-    res, res_headers = handler.run request.body, request.env
-    headers = res_headers
+  res, res_headers = handler.run request.body, request.env
 
-    return res
+  [200, res_headers, res]
 end


### PR DESCRIPTION
Adds an optional third status code as part of the return value.

Is based on https://github.com/openfaas-incubator/ruby-http/issues/6 (can't change the base branch to a forked repo branch).