### PR TITLE
Sinatra headers only accept string hash keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Edit the `homepage/handler.rb` file to return some HTML:
 class Handler
   def run(body, headers)
     status_code = 200 # Optional status code, defaults to 200
-    response_headers = {"content-type": "text/html"}
+    response_headers = {"content-type" => "text/html"}
     body = "<html>Hello world from the Ruby template</html>"
 
     return body, response_headers, status_code

--- a/template/ruby-http/function/handler.rb
+++ b/template/ruby-http/function/handler.rb
@@ -1,7 +1,7 @@
 class Handler
   def run(body, headers)
     status_code = 200 # Optional status code, defaults to 200
-    response_headers = {"content-type": "text/plain"}
+    response_headers = {"content-type" => "text/plain"}
     body = "Hello world from the Ruby template"
 
     return body, response_headers, status_code


### PR DESCRIPTION
The current example handler doesn't work.

The sinatra header hash needs to consists of string keys, not symbol keys. Currently we get:

```
ERROR NoMethodError: undefined method `gsub' for :"content-type":Symbol
```